### PR TITLE
add release pipeline with autobuild

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -9,6 +9,7 @@ on:
 
 jobs:
   build:
+    if: github.event.pull_request.merged == true && github.event.pull_request.base.ref == 'main'
     runs-on: windows-latest
 
     steps:

--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -27,7 +27,7 @@ jobs:
       run: dotnet build StationeersStructureMover.sln --configuration Release --no-restore
 
     - name: Publish
-      run: dotnet publish StationeersStructureMover.csproj --configuration Release --framework net8.0 --runtime win-x64 --self-contained true --output ./publish /p:PublishSingleFile=true /p:IncludeNativeLibrariesForSelfContained=true
+      run: dotnet publish StationeersStructureMover.csproj --configuration Release --framework net8.0-windows --runtime win-x64 --self-contained true --output ./publish /p:PublishSingleFile=true /p:IncludeNativeLibrariesForSelfContained=true
 
     - name: Upload artifact
       uses: actions/upload-artifact@v4

--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -55,4 +55,4 @@ jobs:
           files: ./publish/StationeersStructureMover.exe
           generate_release_notes: false
       env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        GITHUB_TOKEN: ${{ secrets.GH_RELEASE_TOKEN }}

--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -40,6 +40,19 @@ jobs:
       if: startsWith(github.ref, 'refs/tags/')
       uses: softprops/action-gh-release@v2
       with:
-        files: ./publish/StationeersStructureMover.exe
+          name: "StationeersStructureMover ${{ github.ref_name }}"
+          tag_name: ${{ github.ref_name }}
+          body: |
+            ## This is an automated Release created with GitHub Actions
+            ## What's New
+
+            
+            ### Changes
+            - Bug fixes and improvements
+            - Performance enhancements
+          draft: true
+          prerelease: false
+          files: ./publish/StationeersStructureMover.exe
+          generate_release_notes: false
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -9,7 +9,6 @@ on:
 
 jobs:
   build:
-    if: github.event.pull_request.merged == true && github.event.pull_request.base.ref == 'main'
     runs-on: windows-latest
 
     steps:

--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -1,0 +1,45 @@
+name: Build and Release StationeersStructureMover
+
+on:
+  push:
+    branches:
+      - '**'
+  pull_request:
+    types: [closed]
+
+jobs:
+  build:
+    if: github.event.pull_request.merged == true && github.event.pull_request.base.ref == 'main'
+    runs-on: windows-latest
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+
+    - name: Setup .NET
+      uses: actions/setup-dotnet@v4
+      with:
+        dotnet-version: '8.0.x'
+
+    - name: Restore dependencies
+      run: dotnet restore StationeersStructureMover.sln
+
+    - name: Build
+      run: dotnet build StationeersStructureMover.sln --configuration Release --no-restore
+
+    - name: Publish
+      run: dotnet publish StationeersStructureMover.csproj --configuration Release --framework net8.0 --runtime win-x64 --self-contained true --output ./publish /p:PublishSingleFile=true /p:IncludeNativeLibrariesForSelfContained=true
+
+    - name: Upload artifact
+      uses: actions/upload-artifact@v4
+      with:
+        name: StationeersStructureMover
+        path: ./publish/StationeersStructureMover.exe
+
+    - name: Create Release
+      if: startsWith(github.ref, 'refs/tags/')
+      uses: softprops/action-gh-release@v2
+      with:
+        files: ./publish/StationeersStructureMover.exe
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This PR adds a GH Actions release pipeline that builds the [StationeersStructureMover](https://github.com/jhugard/StationeersStructureMover) directly in GH Actions and releases it as a draft release. 

The action will run on _closed, merged PRs to main_